### PR TITLE
Fix date filter with approximate_date

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -1535,6 +1535,11 @@ class YoutubeDL:
                         return '"' + title + '" title matched reject pattern "' + rejecttitle + '"'
 
             date = info_dict.get('upload_date')
+            if date is None:
+                timestamp = info_dict.get('timestamp')
+                if timestamp is not None:
+                    with contextlib.suppress(ValueError, OverflowError, OSError):
+                        date = dt.datetime.utcfromtimestamp(timestamp).strftime('%Y%m%d')
             if date is not None:
                 date_range = self.params.get('daterange', DateRange())
                 if date not in date_range:


### PR DESCRIPTION
## Summary
- use timestamp to honor dateafter when `approximate_date` is enabled

## Testing
- `make test` *(fails: network access to www.youtube.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68653237d5a88326a8bbb63f1d9bb869