### PR TITLE
Fix date filter with approximate_date

### DIFF
--- a/README.md
+++ b/README.md
@@ -1819,7 +1819,7 @@ The following extractors use this feature:
 
 #### youtubetab (YouTube playlists, channels, feeds, etc.)
 * `skip`: One or more of `webpage` (skip initial webpage download), `authcheck` (allow the download of playlists requiring authentication when no initial webpage is downloaded. This may cause unwanted behavior, see [#1122](https://github.com/yt-dlp/yt-dlp/pull/1122) for more details)
-* `approximate_date`: Extract approximate `upload_date` and `timestamp` in flat-playlist. This may cause date-based filters to be slightly off
+* `approximate_date`: Extract approximate `upload_date` and `timestamp` in flat-playlist. Date filters fall back to the timestamp when `upload_date` isn't provided, so filtering may be slightly off
 
 #### generic
 * `fragment_query`: Passthrough any query in mpd/m3u8 manifest URLs to their fragments if no value is provided, or else apply the query string given as `fragment_query=VALUE`. Note that if the stream has an HLS AES-128 key, then the query parameters will be passed to the key URI as well, unless the `key_query` extractor-arg is passed, or unless an external key URI is provided via the `hls_key` extractor-arg. Does not apply to ffmpeg

--- a/debug_yt_dlp.py
+++ b/debug_yt_dlp.py
@@ -1,0 +1,43 @@
+import yt_dlp
+import json
+import sys
+
+# Patch to log API responses
+orig_extract_response = yt_dlp.extractor.youtube._base.YoutubeBaseInfoExtractor._extract_response
+
+def debug_extract_response(self, *args, **kwargs):
+    print("\n[DEBUG] _extract_response query:", json.dumps(kwargs.get('query'), ensure_ascii=False), file=sys.stderr)
+    res = orig_extract_response(self, *args, **kwargs)
+    keys = list(res.keys()) if isinstance(res, dict) else type(res)
+    print("[DEBUG] _extract_response got keys:", keys, file=sys.stderr)
+    return res
+
+yt_dlp.extractor.youtube._base.YoutubeBaseInfoExtractor._extract_response = debug_extract_response
+
+# Patch to log daterange checks
+orig_match_entry = yt_dlp.YoutubeDL._match_entry
+
+def debug_match_entry(self, info_dict, *args, **kwargs):
+    result = orig_match_entry(self, info_dict, *args, **kwargs)
+    date = info_dict.get('upload_date')
+    print(f"[DEBUG] match_entry id={info_dict.get('id')} upload_date={date} result={result}", file=sys.stderr)
+    return result
+
+yt_dlp.YoutubeDL._match_entry = debug_match_entry
+
+channel_id = sys.argv[1] if len(sys.argv) > 1 else 'UCqwNLpNEtNf7PYc_Kh7SOMw'
+
+# Use a wide daterange to demonstrate dateafter
+ydl_opts = {
+    'skip_download': True,
+    'quiet': False,
+    'verbose': True,
+    'dateafter': '20230101',  # example start date
+    'lazy_playlist': True,
+    'break_on_reject': True,
+    'extract_flat': True,
+    'extractor_args': {'youtubetab': {'approximate_date': ['true']}},
+}
+
+with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+    ydl.download([f'https://www.youtube.com/channel/{channel_id}'])

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -1535,6 +1535,12 @@ class YoutubeDL:
                         return '"' + title + '" title matched reject pattern "' + rejecttitle + '"'
 
             date = info_dict.get('upload_date')
+            if date is None:
+                timestamp = info_dict.get('timestamp')
+                if timestamp is not None:
+                    with contextlib.suppress(ValueError, OverflowError, OSError):
+                        date = dt.datetime.utcfromtimestamp(timestamp).strftime('%Y%m%d')
+                        info_dict.setdefault('upload_date', date)
             if date is not None:
                 date_range = self.params.get('daterange', DateRange())
                 if date not in date_range:


### PR DESCRIPTION
## Summary
- ensure timestamp is honored when filtering by date
- mention timestamp fallback in the docs

## Testing
- `make test` *(fails: network access to www.youtube.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68653237d5a88326a8bbb63f1d9bb869