### PR TITLE
Fix date filter with approximate_date

### DIFF
--- a/README.md
+++ b/README.md
@@ -1819,7 +1819,7 @@ The following extractors use this feature:
 
 #### youtubetab (YouTube playlists, channels, feeds, etc.)
 * `skip`: One or more of `webpage` (skip initial webpage download), `authcheck` (allow the download of playlists requiring authentication when no initial webpage is downloaded. This may cause unwanted behavior, see [#1122](https://github.com/yt-dlp/yt-dlp/pull/1122) for more details)
-* `approximate_date`: Extract approximate `upload_date` and `timestamp` in flat-playlist. This may cause date-based filters to be slightly off
+* `approximate_date`: Extract approximate `upload_date` and `timestamp` in flat-playlist. Date filters fall back to the timestamp when `upload_date` isn't provided, so filtering may be slightly off
 
 #### generic
 * `fragment_query`: Passthrough any query in mpd/m3u8 manifest URLs to their fragments if no value is provided, or else apply the query string given as `fragment_query=VALUE`. Note that if the stream has an HLS AES-128 key, then the query parameters will be passed to the key URI as well, unless the `key_query` extractor-arg is passed, or unless an external key URI is provided via the `hls_key` extractor-arg. Does not apply to ffmpeg

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -1535,6 +1535,12 @@ class YoutubeDL:
                         return '"' + title + '" title matched reject pattern "' + rejecttitle + '"'
 
             date = info_dict.get('upload_date')
+            if date is None:
+                timestamp = info_dict.get('timestamp')
+                if timestamp is not None:
+                    with contextlib.suppress(ValueError, OverflowError, OSError):
+                        date = dt.datetime.utcfromtimestamp(timestamp).strftime('%Y%m%d')
+                        info_dict.setdefault('upload_date', date)
             if date is not None:
                 date_range = self.params.get('daterange', DateRange())
                 if date not in date_range:


### PR DESCRIPTION
## Summary
- ensure timestamp is honored when filtering by date
- mention timestamp fallback in the docs

## Testing
- `make test` *(fails: network access to www.youtube.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68653237d5a88326a8bbb63f1d9bb869