### PR TITLE
Handle date options for API users

### DIFF
--- a/debug_yt_dlp.py
+++ b/debug_yt_dlp.py
@@ -5,23 +5,27 @@ import sys
 # Patch to log API responses
 orig_extract_response = yt_dlp.extractor.youtube._base.YoutubeBaseInfoExtractor._extract_response
 
+
 def debug_extract_response(self, *args, **kwargs):
-    print("\n[DEBUG] _extract_response query:", json.dumps(kwargs.get('query'), ensure_ascii=False), file=sys.stderr)
+    print('\n[DEBUG] _extract_response query:', json.dumps(kwargs.get('query'), ensure_ascii=False), file=sys.stderr)
     res = orig_extract_response(self, *args, **kwargs)
     keys = list(res.keys()) if isinstance(res, dict) else type(res)
-    print("[DEBUG] _extract_response got keys:", keys, file=sys.stderr)
+    print('[DEBUG] _extract_response got keys:', keys, file=sys.stderr)
     return res
+
 
 yt_dlp.extractor.youtube._base.YoutubeBaseInfoExtractor._extract_response = debug_extract_response
 
 # Patch to log daterange checks
 orig_match_entry = yt_dlp.YoutubeDL._match_entry
 
+
 def debug_match_entry(self, info_dict, *args, **kwargs):
     result = orig_match_entry(self, info_dict, *args, **kwargs)
     date = info_dict.get('upload_date')
     print(f"[DEBUG] match_entry id={info_dict.get('id')} upload_date={date} result={result}", file=sys.stderr)
     return result
+
 
 yt_dlp.YoutubeDL._match_entry = debug_match_entry
 

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -776,6 +776,13 @@ class YoutubeDL:
         else:
             self.params['nooverwrites'] = not self.params['overwrites']
 
+        if 'daterange' not in self.params:
+            if self.params.get('date') is not None:
+                self.params['daterange'] = DateRange.day(self.params['date'])
+            elif any(k in self.params for k in ('dateafter', 'datebefore')):
+                self.params['daterange'] = DateRange(
+                    self.params.get('dateafter'), self.params.get('datebefore'))
+
         if self.params.get('simulate') is None and any((
             self.params.get('list_thumbnails'),
             self.params.get('listformats'),


### PR DESCRIPTION
## Summary
- respect `date`, `dateafter`, and `datebefore` when using the API
- apply lint/format fixes to debugging script

## Testing
- `PATH=$PATH:.venv/bin .venv/bin/pre-commit run --files yt_dlp/YoutubeDL.py debug_yt_dlp.py`

------
https://chatgpt.com/codex/tasks/task_e_686537b333a48326b5961e52f66bdb3a